### PR TITLE
Fix sqlpath install

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,7 +33,7 @@ class windows_sql::install(
       content => template('windows_sql/checkifinstall.erb'),
     }
     exec{"${action} SQL":
-      command  => "\\setup.exe /CONFIGURATIONFILE='${configurationfile}';",
+      command  => "setup.exe /CONFIGURATIONFILE='${configurationfile}';",
       cwd      => "$sqlpath",
       path     => "$sqlpath",
       provider => 'powershell',


### PR DESCRIPTION
The exec command does not need a leading slash. Otherwise I get 
```
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: \setup.exe : The term '\setup.exe' is not recognized as the name of a cmdlet,
==> default:
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: function, script file, or operable program. Check the spelling of the name, or
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: if a path was included, verify that the path is correct and try again.
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: At line:1 char:1
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: + \setup.exe /CONFIGURATIONFILE='C:\\configurationfile.ini';
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns: + ~~~~~~~~~~
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns:     + CategoryInfo          : ObjectNotFound: (\setup.exe:String) [], CommandN
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns:    otFoundException
==> default: Notice: /Stage[main]/Windows_sql::Install/Exec[Install SQL]/returns:     + FullyQualifiedErrorId : CommandNotFoundException
```